### PR TITLE
Update to OpenDistro 1.13.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazon/opendistro-for-elasticsearch:1.12.0
+FROM amazon/opendistro-for-elasticsearch:1.13.3
 
 WORKDIR /usr/share/elasticsearch
 


### PR DESCRIPTION
This version fixes the vulnerability found in Log4j. See CVE-2021-44228.
