### PR TITLE
Update log4j image library to 2.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,18 @@ RUN elasticsearch-plugin install --batch repository-s3
 RUN elasticsearch-plugin install --batch repository-gcs
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-keystore create
+
+COPY checksums/log4j /tmp/
+
+RUN cd /usr/local/lib && \
+    wget https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.17.0/log4j-core-2.17.0.jar -O log4j-core.jar && \
+    wget https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.17.0/log4j-api-2.17.0.jar -O log4j-api.jar && \
+    wget https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/2.17.0/log4j-slf4j-impl-2.17.0.jar -O log4j-slf4j-impl.jar && \
+    wget https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-1.2-api/2.17.0/log4j-1.2-api-2.17.0.jar -O log4j-1.2-api.jar && \
+    sha1sum -c /tmp/log4j && \
+    rm /tmp/log4j
+
+COPY scripts/replace_log4j.sh /tmp/
+
+RUN /tmp/replace_log4j.sh && \
+    rm /tmp/replace_log4j.sh

--- a/checksums/log4j
+++ b/checksums/log4j
@@ -1,0 +1,4 @@
+aaf998968370edf738322fb750fbda118055508b  log4j-1.2-api.jar
+bbd791e9c8c9421e45337c4fe0a10851c086e36c  log4j-api.jar
+fe6e7a32c1228884b9691a744f953a55d0dd8ead  log4j-core.jar
+1ec25ce0254749c94549ea9c3cea34bd0488c9c6  log4j-slf4j-impl.jar

--- a/scripts/replace_log4j.sh
+++ b/scripts/replace_log4j.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Credits to Robert Spier
+#
+
+find /usr/share/elasticsearch -name 'log4j-*.jar' | while read f; do
+    base=$(basename $(echo $f | sed -e 's/-[0-9]\+\.[0-9]\+\.[0-9]\+\.jar$//'))
+    dir=$(dirname $f)
+    rm $f
+    ln -f /usr/local/lib/${base}.jar $dir
+done


### PR DESCRIPTION
Despite of the base OpenDistro image doesn't have the class that raises the security issues reported as CVE-2021-44228 and CVE-2021-45046, we think it's better to upgrade log4j libraries to the version that fixes those issues.

This patch updates the libraries to 2.17.
